### PR TITLE
Handle missing huggingface_hub gracefully

### DIFF
--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -16,8 +16,18 @@
 
 from functools import lru_cache
 
-from huggingface_hub import get_full_repo_name  # for backward compatibility
-from huggingface_hub.constants import HF_HUB_DISABLE_TELEMETRY as DISABLE_TELEMETRY  # for backward compatibility
+
+try:
+    from huggingface_hub import get_full_repo_name  # for backward compatibility
+    from huggingface_hub.constants import HF_HUB_DISABLE_TELEMETRY as DISABLE_TELEMETRY  # for backward compatibility
+except Exception:
+
+    def get_full_repo_name(*args, **kwargs):  # type: ignore
+        raise ImportError(
+            "huggingface_hub is required to use get_full_repo_name. Install it with `pip install huggingface_hub`."
+        )
+
+    DISABLE_TELEMETRY = True
 from packaging import version
 
 from .. import __version__


### PR DESCRIPTION
## Summary
- avoid hard dependency on `huggingface_hub` by wrapping imports in `utils.__init__`
- provide a stub `get_full_repo_name` with helpful ImportError and default telemetry off

## Testing
- `make fixup` *(fails: No module named 'yaml')*
- `PYTHONPATH=src pytest tests/models/layoutlmv2/test_tokenization_layoutlmv2.py::LayoutLMv2TokenizationTest -q` *(fails: No module named 'regex')*

------
https://chatgpt.com/codex/tasks/task_e_6894f28226888323ad10d2b15f24c518